### PR TITLE
Support relative protocol URLs

### DIFF
--- a/lib/img.js
+++ b/lib/img.js
@@ -25,7 +25,7 @@ const img = async ($, options = {}) => {
     }
     const width = element.attr('width') || size.width
     const height = element.attr('height') || size.height
-    const ampImage = `<amp-img src="${src}" alt="${alt}" width="${width}" height="${height}" layout="responsive" />`
+    const ampImage = `<amp-img src="${url}" alt="${alt}" width="${width}" height="${height}" layout="responsive" />`
     element.replaceWith(ampImage)
   }).get()
   await Promise.all(promises)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html2amp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2313,12 +2313,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2333,17 +2335,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2460,7 +2465,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2472,6 +2478,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2486,6 +2493,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2493,12 +2501,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2517,6 +2527,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2597,7 +2608,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2609,6 +2621,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2730,6 +2743,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/img.test.js
+++ b/test/img.test.js
@@ -25,6 +25,14 @@ describe('img', function () {
       })
     })
   })
+  describe('There is a protocol relative url', function () {
+    const html = htmlFactory({ body: `<img alt="test" src="//dummyimage.com/100x200/000/fff.jpg" />` })
+    it('should be replaced with a custom img tag', async function () {
+      const $ = await img(cheerio.load(html))
+      const expected = htmlFactory({ body: '<amp-img src="https://dummyimage.com/100x200/000/fff.jpg" alt="test" width="100" height="200" layout="responsive"></amp-img>' })
+      assert($, expected)
+    })
+  })
   describe('There is data uri', function () {
     const html = htmlFactory({ body: `<img alt="test" src="${uri}" />` })
     it('should be replaced with custom img tag', async function () {


### PR DESCRIPTION
Hey there!

Thanks for throwing this together. I was following your Gatsby tutorial, and ran into this error when building:

```bash
Fetching https//images.ctfassets.net/sk06mmp11skx/3PUVTXHi8EMiAM06u4CGCq/60e1d406b6b37390e14a8740d3ec3a13/image.png failed.
Fetching https//images.ctfassets.net/sk06mmp11skx/4sPGaAt1JCimsGSksKaoSi/93ee05598b8433048f8488618c008d0c/content-length-header.JPG failed.
error Plugin gatsby-plugin-html2amp returned an error


  TypeError: invalid invocation

  - index.js:101 module.exports
    [gatsby-blog]/[image-size]/lib/index.js:101:11

  - img.js:18 Node.imageElements.map
    [gatsby-blog]/[html2amp]/lib/img.js:18:14



error Command failed with exit code 1.
```

I did some digging and noticed there wasn't a test for the type of URLs provided by Contentful, so I added one and got the test to pass properly (as well as the rest of the tests). I'm not super familiar with AMP, but do we foresee any problems with using the normalized URL for the src moving forward?

Thanks!