### PR TITLE
feat(plugins): Added plugin feature for css and html 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,53 @@ cwd|`.`|image / styles base path
 gaConfigPath| |`amp-analytics` config json path for [google analytics](https://www.ampproject.org/docs/analytics/analytics-vendors)
 serviceWorker| |attributes of [amp-install-serviceworker](https://www.ampproject.org/docs/reference/components/amp-install-serviceworker) <br/> e.g. `src`, `data-iframe-src`
 optimize|false| if true, this module will optimize the html by using [@ampproject/toolbox-optimizer](https://github.com/ampproject/amp-toolbox/tree/master/packages/optimizer)
+cssPlugins | [] | you can add custom converter for css.
+htmlPlugins | [] | you can add custom converter for css.
+
+### CSS Plugin
+
+CSS Plugin allow you to add custom converter for CSS.
+
+```javascript
+/**
+ * elementString :
+ *   e.g. '<style id="test">.test { color: red; }</style>'
+ *   e.g. '<link rel="stylesheet" href="http://example.com/test.css"></style>'
+ * cssText :
+ *   e.g. '.test{ color: red; }'
+ * options : module options
+ **/
+const plugin = (elementString, cssText, options) => {
+  // you need to return cssText which you modified.
+  return cssText.replace('red', '#ccc')
+}
+
+// options
+const options = {
+  cssPlugins: [ plugin ]
+}
+```
+
+### HTMl Plugin
+
+HTML Plugin allow you to add custom converter for HTML.
+
+```javascript
+/**
+ * htmlString :
+ *   e.g. '<html><body><h1>Normal HTML</h1></body></html>'
+ * options : module options
+ **/
+const plugin = (htmlString, options) => {
+  // you need to return htmlString which you modified.
+  return htmlString.replace('Normal', 'AMP')
+}
+
+// options
+const options = {
+  htmlPlugins: [ plugin ]
+}
+```
 
 ## Functions
 

--- a/index.js
+++ b/index.js
@@ -13,9 +13,10 @@ const boilerplate = require('./lib/boilerplate')
 const serviceworker = require('./lib/serviceWorker')
 const link = require('./lib/link')
 const toolbox = require('./lib/toolbox')
+const html = require('./lib/html')
 
-const html2amp = async (html, options = {}) => {
-  let $ = cheerio.load(html)
+const html2amp = async (htmlString, options = {}) => {
+  let $ = cheerio.load(htmlString)
   $ = amp($, options)
   $ = await css($, options)
   $ = await picture($, options) // should be done before img
@@ -28,8 +29,9 @@ const html2amp = async (html, options = {}) => {
   $ = link($)
   $ = serviceworker($, options)
   $ = boilerplate($, options)
-  html = await toolbox.optimizer($.html(), options)
-  return html
+  htmlString = html($, options)
+  htmlString = await toolbox.optimizer(htmlString, options)
+  return htmlString
 }
 
 module.exports = html2amp

--- a/lib/css.js
+++ b/lib/css.js
@@ -1,4 +1,5 @@
 const CleanCss = require('clean-css')
+const cheerio = require('cheerio')
 const utils = require('./utils')
 
 const build = (styles) => {
@@ -6,22 +7,36 @@ const build = (styles) => {
   return styleStr.replace(/!important/g, '')
 }
 
+const callbacks = (elementString, cssText, options = {}) => {
+  const plugins = options.cssPlugins || []
+  return plugins.reduce((css, plugin) => {
+    return plugin(elementString, css, options)
+  }, cssText)
+}
+
 const css = async ($, options) => {
   const styleSheetElements = $('link[rel="stylesheet"]')
   const styleElements = $('style')
-  const cssUrls = styleSheetElements.map((i, node) => utils.normalizeUrl($(node).attr('href'))).get()
-  const styles = cssUrls.map(async url => {
+  const urlElms = Array.from(styleSheetElements).map((node, i) => {
+    const $element = cheerio.load(node)
+    return {
+      url: utils.normalizeUrl($(node).attr('href')),
+      element: $element.html()
+    }
+  })
+  const styles = urlElms.map(async ({ url, elementString }) => {
     if (url.startsWith('http')) {
       const text = await utils.getRemoteFile(url)
-      return text
+      return callbacks(elementString, text, options)
     } else {
       const text = utils.getRelativeFile(url, options.cwd)
-      return text
+      return callbacks(elementString, text, options)
     }
   })
   const texts = await Promise.all(styles)
   styleElements.each((i, element) => {
-    texts.push($(element).html())
+    const $element = cheerio.load(element)
+    texts.push(callbacks($element.html(), $(element).html(), options))
   })
   const styleStr = build(texts)
   $('head').append(`<style amp-custom>${styleStr}</style>`)

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,0 +1,12 @@
+const callbacks = (htmlString, options = {}) => {
+  const plugins = options.htmlPlugins || []
+  return plugins.reduce((html, plugin) => {
+    return plugin(html, options)
+  }, htmlString)
+}
+
+const html = ($, options) => {
+  return callbacks($.html(), options)
+}
+
+module.exports = html

--- a/test/css.test.js
+++ b/test/css.test.js
@@ -43,11 +43,25 @@ describe('css', function () {
     })
   })
   describe('There is inline style', function () {
-    const html = htmlFactory({ head: '<style>.test{color: red !important;}</style>' })
+    const html = htmlFactory({ head: '<style>.test1{color: #000 !important;}</style><style>.test2{color: #ccc !important;}</style>' })
     it('should be appended in custom style tag', async function () {
       const $ = await css(cheerio.load(html))
       assertCss($)
-      expect($('style[amp-custom]').eq(0).html()).toEqual('.test{color:red}')
+      expect($('style[amp-custom]').eq(0).html()).toEqual('.test1{color:#000}.test2{color:#ccc}')
+    })
+  })
+  describe('There is plugin', () => {
+    const html = htmlFactory({ head: '<link rel="stylesheet" href="./styles/test.css">' })
+    it('should be appended in custom style tag', async function () {
+      const plugin = (elementString, cssText) => {
+        return cssText.replace('red', '#ccc')
+      }
+      const options = {
+        cwd: path.join(process.cwd(), 'test/fixtures'),
+        cssPlugins: [plugin]
+      }
+      const $ = await css(cheerio.load(html), options)
+      expect($('style[amp-custom]').eq(0).html()).toEqual('.test{color:#ccc}')
     })
   })
 })

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -1,0 +1,19 @@
+const cheerio = require('cheerio')
+const html = require('../lib/html')
+const htmlFactory = require('./html')
+
+describe('html', function () {
+  describe('There is a plugin', function () {
+    const htmlMock = htmlFactory({ body: '<h1>Normal HTML</h1>' })
+    it('should be modified by plugin', function () {
+      const plugin = htmlString => {
+        return htmlString.replace('Normal', 'AMP')
+      }
+      const options = {
+        htmlPlugins: [plugin]
+      }
+      const htmlString = html(cheerio.load(htmlMock), options)
+      expect(htmlString).toEqual(htmlFactory({ body: '<h1>AMP HTML</h1>' }))
+    })
+  })
+})


### PR DESCRIPTION
### CSS Plugin

CSS Plugin allow you to add custom converter for CSS.

```javascript
/**
 * elementString :
 *   e.g. '<style id="test">.test { color: red; }</style>'
 *   e.g. '<link rel="stylesheet" href="http://example.com/test.css"></style>'
 * cssText :
 *   e.g. '.test{ color: red; }'
 * options : module options
 **/
const plugin = (elementString, cssText, options) => {
  // you need to return cssText which you modified.
  return cssText.replace('red', '#ccc')
}

// options
const options = {
  cssPlugins: [ plugin ]
}
```

### HTMl Plugin

HTML Plugin allow you to add custom converter for HTML.

```javascript
/**
 * htmlString :
 *   e.g. '<html><body><h1>Normal HTML</h1></body></html>'
 * options : module options
 **/
const plugin = (htmlString, options) => {
  // you need to return htmlString which you modified.
  return htmlString.replace('Normal', 'AMP')
}

// options
const options = {
  htmlPlugins: [ plugin ]
}
```