### PR TITLE
fix(link): ignore link replacement function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This library ...
 - replace all a tag links which destination is original site with absolute url which starts with http[s]
   - original url comes from canonical's href attribute
   - e.g. `<a href="/test">` is replaced with `<a href="https//original-url.com/test">`
+  - NOTE: If the canonical url in your html is not absolute url this function would be passed
 - optimize html by using [@ampproject/toolbox-optimizer](https://github.com/ampproject/amp-toolbox/tree/master/packages/optimizer)
 
 ## Preparation

--- a/lib/link.js
+++ b/lib/link.js
@@ -5,6 +5,9 @@ const replaceOriginal = ($, elems, url) => {
     const $org = $(org)
     if ($org.attr('href').startsWith('http')) return
     if ($org.attr('href').startsWith('//')) return
+    if (!url.startsWith('http')) {
+      return
+    }
     const clone = $org.clone()
     clone.attr('href', new URL(clone.attr('href'), url).href)
     $org.replaceWith(clone)


### PR DESCRIPTION
If the canonical url is not absolute url.