### PR TITLE
plugin also need async/await

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const html2amp = async (htmlString, options = {}) => {
   $ = preload($)
   $ = serviceworker($, options)
   $ = boilerplate($, options)
-  htmlString = html($, options)
+  htmlString = await html($, options)
   htmlString = await toolbox.optimizer(htmlString, options)
   return htmlString
 }


### PR DESCRIPTION
目的
　gatsby-plugin-html2ampを利用したいが画像が無効になってしまう。
　原因を調査したらgatsby-imageが画像を出力する時noscriptタグでimgタグを囲んでいました。
　しかしcheerio(parse5)はnoscript内のタグを文字列と認識されるためamp-imgタグに変換されず画像が無効になっていました。
　その問題を回避するプログラムをhtmlPluginを作成したのですがasync/awaitで書いていたため、プルリクエストしました
達成条件
　pluginにもasync / awaitが使えるようにしていただきたい
実装の概要
　index.jsのhtmlメソッド呼び出し時にawait を付けました。
レビューして欲しいところ
　htmlメソッドの中でもawaitを書く必要があるか見ていただけると幸いです。
このプルリクでしないこと
　noscript内のタグを取り出しhtmlに戻す事
レビューの範囲を絞れる
　index.jsとlib/html.js