### PR TITLE
Skip unretrievable Remote Images instead of exiting from probe failure

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,7 +84,7 @@ const srcNode = async (cwd, attributes) => {
     _attrs = { src: url, alt, width: size.width, height: size.height, layout: 'responsive', ..._attrs }
     const _attrsStr = Object.keys(_attrs).map(key => `${key}="${_attrs[key]}"`).join(' ')
     return `<amp-img ${_attrsStr}></amp-img>`
-    }
+  }
   return '';
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,11 +57,17 @@ const srcNode = async (cwd, attributes) => {
   if (url.startsWith('http')) {
     if (remoteImgCaches.has(url)) {
       result = remoteImgCaches.get(url)
+      size = { width: result.width, height: result.height }
     } else {
-      result = await probe(url)
-      remoteImgCaches.set(url, result)
+      try {
+        result = await probe(url)
+        remoteImgCaches.set(url, result)
+        size = { width: result.width, height: result.height }
+      }
+      catch (e) {
+        console.log(`Invalid Asset, Skipping....`)
+      }
     }
-    size = { width: result.width, height: result.height }
   } else if (url.startsWith('data:')) {
     const buffer = uriToBuffer(url)
     result = probe.sync(buffer)
@@ -72,11 +78,14 @@ const srcNode = async (cwd, attributes) => {
     size = { width: result.width, height: result.height }
     fileStream.destroy()
   }
-  // remove loading, type attributes (#80, #104)
-  let { loading, type, ..._attrs } = attrs
-  _attrs = { src: url, alt, width: size.width, height: size.height, layout: 'responsive', ..._attrs }
-  const _attrsStr = Object.keys(_attrs).map(key => `${key}="${_attrs[key]}"`).join(' ')
-  return `<amp-img ${_attrsStr}></amp-img>`
+  if (result != null) {
+    // remove loading, type attributes (#80, #104)
+    let { loading, type, ..._attrs } = attrs
+    _attrs = { src: url, alt, width: size.width, height: size.height, layout: 'responsive', ..._attrs }
+    const _attrsStr = Object.keys(_attrs).map(key => `${key}="${_attrs[key]}"`).join(' ')
+    return `<amp-img ${_attrsStr}></amp-img>`
+    }
+  return '';
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,8 +63,7 @@ const srcNode = async (cwd, attributes) => {
         result = await probe(url)
         remoteImgCaches.set(url, result)
         size = { width: result.width, height: result.height }
-      }
-      catch (e) {
+      } catch (e) {
         console.log(`Invalid Asset, Skipping.... (${url})`)
       }
     }
@@ -85,7 +84,7 @@ const srcNode = async (cwd, attributes) => {
     const _attrsStr = Object.keys(_attrs).map(key => `${key}="${_attrs[key]}"`).join(' ')
     return `<amp-img ${_attrsStr}></amp-img>`
   }
-  return '';
+  return ''
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,7 +78,7 @@ const srcNode = async (cwd, attributes) => {
     size = { width: result.width, height: result.height }
     fileStream.destroy()
   }
-  if (result != null) {
+  if (result !== null) {
     // remove loading, type attributes (#80, #104)
     let { loading, type, ..._attrs } = attrs
     _attrs = { src: url, alt, width: size.width, height: size.height, layout: 'responsive', ..._attrs }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,7 +65,7 @@ const srcNode = async (cwd, attributes) => {
         size = { width: result.width, height: result.height }
       }
       catch (e) {
-        console.log(`Invalid Asset, Skipping....`)
+        console.log(`Invalid Asset, Skipping.... (${url})`)
       }
     }
   } else if (url.startsWith('data:')) {

--- a/test/img.test.js
+++ b/test/img.test.js
@@ -57,4 +57,12 @@ describe('img', function () {
       assert($, expected)
     })
   })
+  describe('unavailable images are ignored', function () {
+    const html = htmlFactory({ body: '<img alt="test" loading="lazy" src="https://example.com/404.jpg" />' })
+    it('should be removed', async () => {
+      const $ = await img(cheerio.load(html), { cwd: path.join(process.cwd(), 'test/fixtures') })
+      const expected = htmlFactory({ body: '' })
+      assert($, expected)
+    })
+  })
 })

--- a/test/img.test.js
+++ b/test/img.test.js
@@ -58,7 +58,7 @@ describe('img', function () {
     })
   })
   describe('Unavailable images are ignored', function () {
-    const html = htmlFactory({ body: '<img alt="test" loading="lazy" src="https://example.com/404.jpg" />' })
+    const html = htmlFactory({ body: '<img alt="test" src="https://example.com/404.jpg" />' })
     it('amp-img tag should not be rendered', async () => {
       const $ = await img(cheerio.load(html))
       const expected = htmlFactory({ body: '' })

--- a/test/img.test.js
+++ b/test/img.test.js
@@ -60,7 +60,7 @@ describe('img', function () {
   describe('Unavailable images are ignored', function () {
     const html = htmlFactory({ body: '<img alt="test" loading="lazy" src="https://example.com/404.jpg" />' })
     it('amp-img tag should not be rendered', async () => {
-      const $ = await img(cheerio.load(html), { cwd: path.join(process.cwd(), 'test/fixtures') })
+      const $ = await img(cheerio.load(html))
       const expected = htmlFactory({ body: '' })
       assert($, expected)
     })

--- a/test/img.test.js
+++ b/test/img.test.js
@@ -57,9 +57,9 @@ describe('img', function () {
       assert($, expected)
     })
   })
-  describe('unavailable images are ignored', function () {
+  describe('Unavailable images are ignored', function () {
     const html = htmlFactory({ body: '<img alt="test" loading="lazy" src="https://example.com/404.jpg" />' })
-    it('should be removed', async () => {
+    it('amp-img tag should not be rendered', async () => {
       const $ = await img(cheerio.load(html), { cwd: path.join(process.cwd(), 'test/fixtures') })
       const expected = htmlFactory({ body: '' })
       assert($, expected)


### PR DESCRIPTION
@tomoyukikashiro , we've been using the PR for some time, hoping this will get your approval. This little tweak skips the unavailable images during amp page generation from the original page, instead of exiting from Probe Failure.